### PR TITLE
Websocketting refresh issue

### DIFF
--- a/client/cypress/e2e/grid-component.cy.ts
+++ b/client/cypress/e2e/grid-component.cy.ts
@@ -38,15 +38,15 @@ describe('Grid Component', () => {
 
   it('should black-out the cell with all edges bolded', () => {
     cy.get('#mat-input-3').click({ ctrlKey: true });
-    cy.get('#mat-input-103') // the current cell becomes 103 when its bold idk why we kinda have jank cell names
+    cy.get('#mat-input-3') // the current cell becomes 103 when its bold idk why we kinda have jank cell names
       .should('have.css', 'background-color')
       .and('eq', 'rgb(0, 0, 0)');
   });
 
   it('should un-black cell background, but keep edges', () => {
     cy.get('#mat-input-3').click({ ctrlKey: true });
-    cy.get('#mat-input-103').click({ altKey: true });
-    cy.get('#mat-input-203') // the current cell become 203, also idk why but f it we ball
+    cy.get('#mat-input-3').click({ altKey: true });
+    cy.get('#mat-input-3') // the current cell become 203, also idk why but f it we ball
       .should('have.css', 'background-color')
       .and('eq', 'rgb(255, 255, 255)');
   });
@@ -54,7 +54,7 @@ describe('Grid Component', () => {
   it('should highlight cell', () => {
     cy.get('#mat-radio-2-input').click();
     cy.get('#mat-input-3').rightclick();
-    cy.get('#mat-input-103')
+    cy.get('#mat-input-3')
       .should('have.css', 'background-color')
       .and('eq', 'rgb(255, 192, 203)');
   });
@@ -62,8 +62,8 @@ describe('Grid Component', () => {
   it('should un-highlight cell', () => {
     cy.get('#mat-radio-2-input').click();
     cy.get('#mat-input-3').rightclick();
-    cy.get('#mat-input-103').rightclick();
-    cy.get('#mat-input-203')
+    cy.get('#mat-input-3').rightclick();
+    cy.get('#mat-input-3')
       .should('have.css', 'background-color')
       .and('eq', 'rgb(255, 255, 255)');
   });
@@ -71,7 +71,7 @@ describe('Grid Component', () => {
   it('should highlight cell on mouseleave', () => {
     cy.get('#mat-radio-2-input').click();
     cy.get('#mat-input-3').trigger('mouseleave', {shiftKey: true});
-    cy.get('#mat-input-103')
+    cy.get('#mat-input-3')
       .should('have.css', 'background-color')
       .and('eq', 'rgb(255, 192, 203)');
   });

--- a/client/cypress/e2e/grid-component.cy.ts
+++ b/client/cypress/e2e/grid-component.cy.ts
@@ -8,18 +8,11 @@ describe('Grid Component', () => {
     cy.task('seed:database');
   });
 
-  // it('should open saved grid to server', () => {
-  //   cy.get(':nth-child(2) > .ng-star-inserted > button').click();
-  //   cy.get(':nth-child(2) > .ng-star-inserted > button').click();
-  //   cy.intercept('api/grid').as('saveGrids');
-  //   cy.url().should('contain', '/seededGrids/grid/673ba3a31e6a570b74f9a310');
-  // });
-
   it('should save a grid to server', () => {
     page.saveGrid();
     cy.wait(3000);
     cy.get(':nth-child(3) > :nth-child(2) > :nth-child(3) > button').click();
-    cy.get(':nth-child(3) > :nth-child(2) > :nth-child(3) > button').click(); // these buttons wouldn't show up if it saves, i promise this test actually checks for something
+    cy.get(':nth-child(3) > :nth-child(2) > :nth-child(3) > button').click();
 
   });
 
@@ -38,7 +31,7 @@ describe('Grid Component', () => {
 
   it('should black-out the cell with all edges bolded', () => {
     cy.get('#mat-input-3').click({ ctrlKey: true });
-    cy.get('#mat-input-3') // the current cell becomes 103 when its bold idk why we kinda have jank cell names
+    cy.get('#mat-input-3')
       .should('have.css', 'background-color')
       .and('eq', 'rgb(0, 0, 0)');
   });
@@ -46,7 +39,7 @@ describe('Grid Component', () => {
   it('should un-black cell background, but keep edges', () => {
     cy.get('#mat-input-3').click({ ctrlKey: true });
     cy.get('#mat-input-3').click({ altKey: true });
-    cy.get('#mat-input-3') // the current cell become 203, also idk why but f it we ball
+    cy.get('#mat-input-3')
       .should('have.css', 'background-color')
       .and('eq', 'rgb(255, 255, 255)');
   });

--- a/client/src/app/grid-cell/grid-cell.component.ts
+++ b/client/src/app/grid-cell/grid-cell.component.ts
@@ -51,10 +51,10 @@ export class GridCellComponent {
   onInput(value: string) {
     if (this.validateInput(value)) {
       this.gridCell.value = value;
-      this.gridChange.emit({ row: this.row, col: this.col, cell: this.gridCell });
     } else {
       this.gridCell.value = '';
     }
+    this.gridChange.emit({ row: this.row, col: this.col, cell: this.gridCell });
   }
 
   /**

--- a/client/src/app/grid-cell/grid-cell.component.ts
+++ b/client/src/app/grid-cell/grid-cell.component.ts
@@ -32,7 +32,7 @@ export class GridCellComponent {
   @Input({}) grid: GridCell[][];
   @Input() currentColor: string;
 
-  @Output() gridChange = new EventEmitter<void>();
+  @Output() gridChange = new EventEmitter<{row: number, col: number, cell: GridCell}>();
 
   /**
    * Constructor for GridCellComponent.
@@ -51,7 +51,7 @@ export class GridCellComponent {
   onInput(value: string) {
     if (this.validateInput(value)) {
       this.gridCell.value = value;
-      this.gridChange.emit();
+      this.gridChange.emit({ row: this.row, col: this.col, cell: this.gridCell });
     } else {
       this.gridCell.value = '';
     }
@@ -81,6 +81,7 @@ export class GridCellComponent {
    */
   setColor(color: string) {
     this.gridCell.color = color;
+    this.gridChange.emit({ row: this.row, col: this.col, cell: this.gridCell });
   }
 
   /**
@@ -191,7 +192,7 @@ export class GridCellComponent {
     }
     this.cellCheck('');
     if (emitChange) {
-      this.gridChange.emit();
+      this.gridChange.emit({ row: this.row, col: this.col, cell: this.gridCell });
     }
   }
 
@@ -214,11 +215,10 @@ export class GridCellComponent {
           }
         }
       }
-      this.gridChange.emit();
+      this.gridChange.emit({ row: this.row, col: this.col, cell: this.gridCell });
     } else if (event.altKey) {
       if (this.allEdgeCheck(0, 0)) {
         this.setColor('white');
-        this.gridChange.emit();
       }
     }
   }
@@ -241,7 +241,6 @@ export class GridCellComponent {
           this.setColor('');
         }
       }
-      this.gridChange.emit();
     }
   }
 
@@ -258,7 +257,6 @@ export class GridCellComponent {
           this.setColor('');
         }
       }
-      this.gridChange.emit();
     }
   }
 

--- a/client/src/app/grid/grid-list.component.ts
+++ b/client/src/app/grid/grid-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, Input, OnInit } from '@angular/core';
 import { GridCardComponent } from "./grid-card.component";
-import { ActivatedRoute, RouterLink, RouterModule } from '@angular/router';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 import { GridPackage } from './gridPackage';
 import { GridService } from './grid.service';
 import { RoomService } from '../room.service';
@@ -10,7 +10,7 @@ import { HttpClientModule } from '@angular/common/http';
 @Component({
   selector: 'app-grid-list',
   standalone: true,
-  imports: [GridCardComponent, RouterLink, RouterModule, MatCardModule, HttpClientModule],
+  imports: [GridCardComponent, RouterModule, MatCardModule, HttpClientModule],
   templateUrl: './grid-list.component.html',
   styleUrl: './grid-list.component.scss'
 })

--- a/client/src/app/grid/grid.component.html
+++ b/client/src/app/grid/grid.component.html
@@ -172,7 +172,7 @@
           [grid]="gridPackage.grid"
           [currentColor]="currentColor"
           [ngStyle]="{ height: cellSize + 'px', width: cellSize + 'px' }"
-          (gridChange)="onGridChange()"
+          (gridChange)="onGridChange($event)"
         ></app-grid-cell>
       </mat-grid-tile>
       } }

--- a/client/src/app/grid/grid.component.spec.ts
+++ b/client/src/app/grid/grid.component.spec.ts
@@ -318,7 +318,7 @@ describe('GridComponent', () => {
     component.onGridChange();
 
     expect(sendMessageSpy).toHaveBeenCalledWith({
-      type: 'GRID_UPDATE',
+      type: 'GRID_CELL_UPDATE',
       grid: mockGrid,
       roomID: 'testRoomId',
       id: 'testId'
@@ -331,7 +331,7 @@ describe('GridComponent', () => {
       [new GridCell(), new GridCell()]
     ];
     const message = {
-      type: 'GRID_UPDATE',
+      type: 'GRID_CELL_UPDATE',
       grid: mockGrid,
       id: 'testId'
     };

--- a/client/src/app/grid/grid.component.spec.ts
+++ b/client/src/app/grid/grid.component.spec.ts
@@ -18,7 +18,7 @@ describe('GridComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [],
-      imports: [FormsModule, GridComponent, BrowserAnimationsModule, RouterTestingModule, HttpClientTestingModule],
+      imports: [FormsModule, BrowserAnimationsModule, RouterTestingModule, HttpClientTestingModule, GridComponent],
       providers: [
         { provide: GridService, useValue: new MockGridService() },
         RoomService
@@ -307,32 +307,31 @@ describe('GridComponent', () => {
 
   it('should send grid update message on grid change', () => {
     const sendMessageSpy = spyOn(component['webSocketService'], 'sendMessage');
-    const mockGrid: GridCell[][] = [
-      [new GridCell(), new GridCell()],
-      [new GridCell(), new GridCell()]
-    ];
-    component.gridPackage.grid = mockGrid;
+    const mockGridCell: GridCell = new GridCell();
+    mockGridCell.value = 'X';
+    component.gridPackage.grid[1][1] = mockGridCell;
     component.gridPackage._id = 'testId';
     component.gridPackage.roomID = 'testRoomId';
 
-    component.onGridChange();
+    component.onGridChange({ row: 1, col: 1, cell: mockGridCell });
 
     expect(sendMessageSpy).toHaveBeenCalledWith({
       type: 'GRID_CELL_UPDATE',
-      grid: mockGrid,
-      roomID: 'testRoomId',
-      id: 'testId'
+      cell: mockGridCell,
+      row: 1,
+      col: 1,
+      gridID: 'testId'
     });
   });
 
   it('should handle websocket messages correctly', fakeAsync(() => {
-    const mockGrid: GridCell[][] = [
-      [new GridCell(), new GridCell()],
-      [new GridCell(), new GridCell()]
-    ];
+    const mockGridCell: GridCell = new GridCell();
+    mockGridCell.value = 'X';
     const message = {
       type: 'GRID_CELL_UPDATE',
-      grid: mockGrid,
+      cell: mockGridCell,
+      row: 1,
+      col: 1,
       id: 'testId'
     };
 
@@ -341,17 +340,15 @@ describe('GridComponent', () => {
 
     // This is a workaround to make the test work
     component['webSocketService'].getMessage().subscribe((msg: unknown) => {
-      const receivedMessage = msg as { type: string, grid: GridCell[][], id: string };
-      if (receivedMessage.type === 'GRID_UPDATE' && component.gridPackage._id === receivedMessage.id) {
-        component.applyGridUpdate(receivedMessage.grid);
+      const receivedMessage = msg as { type: string, cell: GridCell, row: number, col: number, id: string };
+      if (receivedMessage.type === 'GRID_CELL_UPDATE' && component.gridPackage._id === receivedMessage.id) {
+        component.gridPackage.grid[receivedMessage.row][receivedMessage.col] = receivedMessage.cell;
       }
     });
 
     tick();
 
-    expect(component.gridPackage.grid).toEqual(mockGrid);
-    expect(component.gridHeight).toBe(mockGrid.length);
-    expect(component.gridWidth).toBe(mockGrid[0].length);
+    expect(component.gridPackage.grid[1][1].value).toBe('X');
   }));
 });
 

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -110,6 +110,19 @@ export class GridComponent {
         this.gridPackage.grid[msg.row][msg.col].color = msg.cell.color;
         this.gridPackage.grid[msg.row][msg.col].edges = msg.cell.edges;
         this.gridPackage.grid[msg.row][msg.col].value = msg.cell.value;
+
+        if (this.gridPackage.grid[msg.row + 1][msg.col]) {
+          this.gridPackage.grid[msg.row + 1][msg.col].edges.top = msg.cell.edges.bottom;
+        }
+        if (this.gridPackage.grid[msg.row - 1][msg.col]) {
+          this.gridPackage.grid[msg.row - 1][msg.col].edges.bottom = msg.cell.edges.top;
+        }
+        if (this.gridPackage.grid[msg.row][msg.col + 1]) {
+          this.gridPackage.grid[msg.row][msg.col + 1].edges.left = msg.cell.edges.right;
+        }
+        if (this.gridPackage.grid[msg.row][msg.col - 1]) {
+          this.gridPackage.grid[msg.row][msg.col - 1].edges.right = msg.cell.edges.left;
+        }
       }
     });
   }

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -20,7 +20,6 @@ import {
   MatExpansionPanel,
   MatExpansionPanelDescription,
   MatExpansionPanelHeader,
-  MatExpansionPanelTitle,
 } from '@angular/material/expansion';
 import { MatIcon } from '@angular/material/icon';
 
@@ -43,7 +42,6 @@ import { MatIcon } from '@angular/material/icon';
     MatCardModule,
     MatExpansionPanel,
     MatExpansionPanelHeader,
-    MatExpansionPanelTitle,
     MatExpansionPanelDescription,
     MatIcon,
   ],
@@ -107,7 +105,11 @@ export class GridComponent {
       }; // all of these are optional to allow heartbeat messages to pass through
 
       if (msg.type === 'GRID_CELL_UPDATE' && this.gridPackage._id === msg.gridID) {
-        this.gridPackage.grid[msg.row][msg.col] = msg.cell;
+        // this.gridPackage.grid[msg.row][msg.col] = msg.cell;
+
+        this.gridPackage.grid[msg.row][msg.col].color = msg.cell.color;
+        this.gridPackage.grid[msg.row][msg.col].edges = msg.cell.edges;
+        this.gridPackage.grid[msg.row][msg.col].value = msg.cell.value;
       }
     });
   }
@@ -282,7 +284,9 @@ export class GridComponent {
             break;
           default:
             if (event.key.length === 1 && event.key.match(/[a-zA-Z]/)) {
-              cell.value = event.key;
+
+              this.renderer.setProperty(inputElement, 'value', event.key);
+              inputElement.dispatchEvent(new Event('input'));
 
               if (this.typeDirection === 'right') {
                 if (cell.edges.right === false) {

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -329,10 +329,11 @@ export class GridComponent {
         switch (event.key) {
           case 'Backspace':
             if (inputElement) {
-              console.log(inputElement.value);
               this.renderer.setProperty(inputElement, 'value', '');
-              setTimeout(() => this.moveFocus(col, row), 0);
-              console.log(inputElement.value);
+              inputElement.dispatchEvent(new Event('input'));
+              cell.value = '';
+
+              this.moveFocus(col, row);
             }
         }
       }

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -287,6 +287,7 @@ export class GridComponent {
 
               this.renderer.setProperty(inputElement, 'value', event.key);
               inputElement.dispatchEvent(new Event('input'));
+              cell.value = event.key;
 
               if (this.typeDirection === 'right') {
                 if (cell.edges.right === false) {

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -113,15 +113,19 @@ export class GridComponent {
 
         if (this.gridPackage.grid[msg.row + 1][msg.col]) {
           this.gridPackage.grid[msg.row + 1][msg.col].edges.top = msg.cell.edges.bottom;
+          this.updateCellColor(msg.row + 1, msg.col);
         }
         if (this.gridPackage.grid[msg.row - 1][msg.col]) {
           this.gridPackage.grid[msg.row - 1][msg.col].edges.bottom = msg.cell.edges.top;
+          this.updateCellColor(msg.row - 1, msg.col);
         }
         if (this.gridPackage.grid[msg.row][msg.col + 1]) {
           this.gridPackage.grid[msg.row][msg.col + 1].edges.left = msg.cell.edges.right;
+          this.updateCellColor(msg.row, msg.col + 1);
         }
         if (this.gridPackage.grid[msg.row][msg.col - 1]) {
           this.gridPackage.grid[msg.row][msg.col - 1].edges.right = msg.cell.edges.left;
+          this.updateCellColor(msg.row, msg.col - 1);
         }
       }
     });
@@ -385,5 +389,14 @@ export class GridComponent {
   deleteDirectionToggle() {
     this.deleteDirectionBool = !this.deleteDirectionBool;
     console.log(this.deleteDirectionBool);
+  }
+
+  updateCellColor(row: number, col: number) {
+    const cell = this.gridPackage.grid[row][col];
+    if (cell.edges.top && cell.edges.right && cell.edges.bottom && cell.edges.left) {
+      cell.color = 'black';
+    } else {
+      cell.color = '';
+    }
   }
 }

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -100,17 +100,14 @@ export class GridComponent {
     this.webSocketService.getMessage().subscribe((message: unknown) => {
       const msg = message as {
         type?: string;
-        grid?: GridCell[][];
-        id?: string;
-      };
-      // all of these are optional to allow heartbeat messages to pass through
-      if (
-        // checks that message was a grid update
-        msg.type === 'GRID_UPDATE' &&
-        // checks that grid you have open is the same as the one that was updated
-        this.gridPackage._id == (message as { id: string }).id
-      ) {
-        this.applyGridUpdate(msg.grid);
+        gridID?: string;
+        cell?: GridCell;
+        row?: number;
+        col?: number;
+      }; // all of these are optional to allow heartbeat messages to pass through
+
+      if (msg.type === 'GRID_CELL_UPDATE' && this.gridPackage._id === msg.gridID) {
+        this.gridPackage.grid[msg.row][msg.col] = msg.cell;
       }
     });
   }
@@ -192,18 +189,19 @@ export class GridComponent {
     });
   }
 
-  onGridChange() {
+  onGridChange(event: { row: number, col: number, cell: GridCell }) {
     const message = {
-      type: 'GRID_UPDATE',
-      grid: this.gridPackage.grid,
-      roomID: this.gridPackage.roomID,
-      id: this.gridPackage._id,
+      type: 'GRID_CELL_UPDATE',
+      cell: event.cell,
+      row: event.row,
+      col: event.col,
+      gridID: this.gridPackage._id,
     };
+
     this.webSocketService.sendMessage(message);
   }
 
   /**
-   * Handles the click event on a grid cell.
    * Moves the focus to the clicked cell.
    *
    * @param event - The mouse event.
@@ -363,6 +361,7 @@ export class GridComponent {
     this.typeDirection = this.typingDirections[this.currentDirectionIndex];
     console.log(`Typing direction changed to: ${this.typeDirection}`);
   }
+
 
   deleteDirectionToggle() {
     this.deleteDirectionBool = !this.deleteDirectionBool;

--- a/client/src/app/grid/grid.component.ts
+++ b/client/src/app/grid/grid.component.ts
@@ -395,8 +395,6 @@ export class GridComponent {
     const cell = this.gridPackage.grid[row][col];
     if (cell.edges.top && cell.edges.right && cell.edges.bottom && cell.edges.left) {
       cell.color = 'black';
-    } else {
-      cell.color = '';
     }
   }
 }


### PR DESCRIPTION
For the longest time we had an issue with websocketting where it would refresh the entire grid on a message received. This made it so the cursor would unfocus and the user would have to re-click into the grid.

This issue is now fixed, and tests account for this